### PR TITLE
fix error when using context_recall metric but don't validate passages

### DIFF
--- a/RAGchain/benchmark/base.py
+++ b/RAGchain/benchmark/base.py
@@ -38,6 +38,8 @@ class BaseEvaluator(ABC):
         """
         Evaluate metrics and return the results
         :param validate_passages: If True, validate passages in retrieval_gt already ingested.
+        If False, you can't use context_recall and KF1 metrics.
+        We recommend to set True for robust evaluation.
         :return: EvaluateResult
         """
         pass
@@ -85,7 +87,6 @@ class BaseEvaluator(ABC):
         # without gt - retrieval & answer
         ragas_metrics = self.__ragas_metrics()
         if len(ragas_metrics) > 0:
-            from ragas import evaluate
             from ragas.metrics import context_recall
             # You can't use context_recall when retrieval_gt is None or don't validate passages.
             if retrieval_gt is None or 'retrieval_gt_contents' not in result_df.columns:
@@ -93,6 +94,8 @@ class BaseEvaluator(ABC):
                                  isinstance(metric, type(context_recall)) is False]
             else:
                 warnings.warn("You can't use context_recall when retrieval_gt is None or don't validate passages.")
+        if len(ragas_metrics) > 0:
+            from ragas import evaluate
             use_metrics += [metric.name for metric in ragas_metrics]
 
             dataset_dict = {

--- a/tests/RAGchain/benchmark/dataset/test_ko_strategy_qa.py
+++ b/tests/RAGchain/benchmark/dataset/test_ko_strategy_qa.py
@@ -20,7 +20,8 @@ def ko_strategy_qa_evaluator():
     db = PickleDB(pickle_path)
     pipeline = BasicRunPipeline(bm25_retrieval, OpenAI(model_name="babbage-002"))
     evaluator = KoStrategyQAEvaluator(pipeline, evaluate_size=5,
-                                      metrics=['Recall', 'Precision', 'Hole', 'TopK_Accuracy', 'EM', 'F1_score'])
+                                      metrics=['Recall', 'Precision', 'Hole', 'TopK_Accuracy', 'EM', 'F1_score',
+                                               'context_precision'])
     evaluator.ingest([bm25_retrieval], db, ingest_size=20)
     yield evaluator
     if os.path.exists(bm25_path):

--- a/tests/RAGchain/benchmark/dataset/test_startegy_qa.py
+++ b/tests/RAGchain/benchmark/dataset/test_startegy_qa.py
@@ -20,7 +20,8 @@ def strategy_qa_evaluator():
     db = PickleDB(pickle_path)
     pipeline = BasicRunPipeline(bm25_retrieval, OpenAI(model_name='babbage-002'))
     evaluator = StrategyQAEvaluator(pipeline, evaluate_size=5,
-                                    metrics=['Recall', 'Precision', 'Hole', 'TopK_Accuracy', 'EM', 'F1_score'])
+                                    metrics=['Recall', 'Precision', 'Hole', 'TopK_Accuracy', 'EM', 'F1_score',
+                                             'context_recall', 'context_precision'])
     evaluator.ingest([bm25_retrieval], db, ingest_size=20)
     yield evaluator
     if os.path.exists(bm25_path):
@@ -38,4 +39,5 @@ def test_ko_strategy_qa_evaluator(strategy_qa_evaluator):
     assert result.each_results.iloc[0][
                'question'] == 'Are more people today related to Genghis Khan than Julius Caesar?'
     assert result.each_results.iloc[0]['answer_pred']
-    assert len(result.use_metrics) == len(strategy_qa_evaluator.metrics)
+    # you can't use context_recall when validate_passages is False
+    assert len(result.use_metrics) == len(strategy_qa_evaluator.metrics) - 1


### PR DESCRIPTION
close #347 

There was error when you want to use context_recall, but not using context_precision, and don't validate passages. 
`use_metrics` value turns to empty list, so it occurs error at ragas library. 

So I fix to check one more time after removing context_recall at ragas_metrics list. 